### PR TITLE
fix: 소켓 연결 상태에 따른 컴포넌트 전환 로직 개선

### DIFF
--- a/src/components/content/canvas/MainCanvas.tsx
+++ b/src/components/content/canvas/MainCanvas.tsx
@@ -1,41 +1,49 @@
-import {Canvas} from "@react-three/fiber";
-import {OrbitControls} from "@react-three/drei";
-import {RootMap} from "./maps/RootMap.tsx";
-
+import { Canvas } from "@react-three/fiber";
+import { OrbitControls } from "@react-three/drei";
+import { RootMap } from "./maps/RootMap.tsx";
+import { useRecoilValue } from "recoil";
+import { SocketStatusAtom } from "../../../store/SocketAtom";
+import Lobby from "../lobby/Lobby";
 
 const MainCanvas = () => {
-    const aspectRatio: number = window.innerWidth / window.innerHeight;
-    return (
-        <Canvas
-            id="canvas"
-            gl={{antialias: true}}
-            shadows
-            camera={{
-                fov: 30,
-                aspect: aspectRatio,
-                near: 0.01,
-                far: 100000,
-                position: [12, 12, 12]
-            }}
-        >
-            <ambientLight intensity={5} name="ambientLight"/>
-            <directionalLight
-                castShadow
-                intensity={5}
-                position={[0, 50, -50]}
-                shadow-normalBias={0.1}
-                shadow-camera-left={-25}
-                shadow-camera-right={25}
-                shadow-camera-top={25}
-                shadow-camera-bottom={-25}
-                shadow-camera-near={0.1}
-                shadow-camera-far={200}
-            />
-            <OrbitControls/>
+  const aspectRatio: number = window.innerWidth / window.innerHeight;
+  const socketStatus = useRecoilValue(SocketStatusAtom);
 
-            <RootMap/>
-        </Canvas>
-    );
+  if (!socketStatus.isConnected) {
+    return <Lobby />;
+  }
+
+  return (
+    <Canvas
+      id="canvas"
+      gl={{ antialias: true }}
+      shadows
+      camera={{
+        fov: 30,
+        aspect: aspectRatio,
+        near: 0.01,
+        far: 100000,
+        position: [12, 12, 12],
+      }}
+    >
+      <ambientLight intensity={5} name="ambientLight" />
+      <directionalLight
+        castShadow
+        intensity={5}
+        position={[0, 50, -50]}
+        shadow-normalBias={0.1}
+        shadow-camera-left={-25}
+        shadow-camera-right={25}
+        shadow-camera-top={25}
+        shadow-camera-bottom={-25}
+        shadow-camera-near={0.1}
+        shadow-camera-far={200}
+      />
+      <OrbitControls />
+
+      <RootMap />
+    </Canvas>
+  );
 };
 
 export default MainCanvas;


### PR DESCRIPTION
## 🔧연결된 이슈
- #52 

## 🛠️작업 내용

- MainCanvas에서 소켓 연결이 없을 때 Lobby 컴포넌트로 직접 전환하도록 수정
- react-router-dom 의존성 제거 및 라우팅 로직 제거
- 불필요한 useEffect 제거로 성능 개선
- 컴포넌트 간 직접 전환으로 사용자 경험 개선

이 변경으로 소켓 연결이 끊어졌을 때 사용자가 즉시 Lobby로 돌아갈 수 있게 됨.

