### PR TITLE
fix: 소켓 연결 끊김 시 카메라 자유시점 전환 버그 수정

### DIFF
--- a/src/components/content/canvas/MainCanvas.tsx
+++ b/src/components/content/canvas/MainCanvas.tsx
@@ -4,13 +4,35 @@ import { RootMap } from "./maps/RootMap.tsx";
 import { useRecoilValue } from "recoil";
 import { SocketStatusAtom } from "../../../store/SocketAtom";
 import Lobby from "../lobby/Lobby";
+import styled from "styled-components";
+
+const ReconnectMessage = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 20px;
+  border-radius: 10px;
+  text-align: center;
+  z-index: 1000;
+`;
 
 const MainCanvas = () => {
   const aspectRatio: number = window.innerWidth / window.innerHeight;
   const socketStatus = useRecoilValue(SocketStatusAtom);
 
   if (!socketStatus.isConnected) {
-    return <Lobby />;
+    return (
+      <>
+        <Lobby />
+        <ReconnectMessage>
+          <h2>연결이 끊어졌습니다</h2>
+          <p>페이지를 새로고침하여 재접속해주세요.</p>
+        </ReconnectMessage>
+      </>
+    );
   }
 
   return (
@@ -39,8 +61,7 @@ const MainCanvas = () => {
         shadow-camera-near={0.1}
         shadow-camera-far={200}
       />
-      <OrbitControls />
-
+      <OrbitControls enabled={socketStatus.isConnected} />
       <RootMap />
     </Canvas>
   );


### PR DESCRIPTION
## 🔧연결된 이슈
- #55 

## 🛠️작업 내용
fix: 소켓 연결 끊김 시 카메라 자유시점 전환 버그 수정
- 소켓 연결이 끊어졌을 때 OrbitControls 비활성화
- 재접속 안내 메시지 UI 추가
- 네트워크 불안정 상황에서의 사용자 경험 개선


## 🤷‍♂️PR이 필요한 이유
- 소켓 연결이 끊기거나 네트워크 불안정으로 인해 플레이어가 의도치 않게 자유시점으로 전환되는 문제 해결

## 📸스크린샷 (선택)
- 스크린샷