### PR TITLE
fix: 그림자 렌더링 품질 개선 및 영역 문제 해결

### DIFF
--- a/src/components/content/canvas/MainCanvas.tsx
+++ b/src/components/content/canvas/MainCanvas.tsx
@@ -54,10 +54,12 @@ const MainCanvas = () => {
         intensity={5}
         position={[0, 50, -50]}
         shadow-normalBias={0.1}
-        shadow-camera-left={-25}
-        shadow-camera-right={25}
-        shadow-camera-top={25}
-        shadow-camera-bottom={-25}
+        shadow-bias={-0.001}
+        shadow-mapSize={[2048, 2048]}
+        shadow-camera-left={-100}
+        shadow-camera-right={100}
+        shadow-camera-top={100}
+        shadow-camera-bottom={-100}
         shadow-camera-near={0.1}
         shadow-camera-far={200}
       />


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #54 

## 🛠️작업 내용
fix: 그림자 렌더링 품질 개선
- 그림자 맵 해상도를 2048x2048로 증가하여 선명도 향상
- shadow-bias 속성 추가로 그림자 아티팩트 감소
- 그림자 영역은 유지하면서 렌더링 품질만 개선


## 🤷‍♂️PR이 필요한 이유
- 그림자가 특정 영역에서 연하게 표시되는 문제 해결

## 📸스크린샷 (선택)
### Before
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/161e7888-91c5-4ba1-a59d-83d32d5de1b6" />

### After
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/68e06998-9e27-4fff-9b8f-a27888283b45" />
